### PR TITLE
Fix image repositories and update v4.17 Dockerfile

### DIFF
--- a/.tekton/openshift-builds-fbc-v4-12-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-v4-12-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-12/openshift-builds-fbc-v4-12:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/openshift-builds-fbc-v4-12-push.yaml
+++ b/.tekton/openshift-builds-fbc-v4-12-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-12/openshift-builds-fbc-v4-12:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/openshift-builds-fbc-v4-13-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-v4-13-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-13/openshift-builds-fbc-v4-13:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/openshift-builds-fbc-v4-13-push.yaml
+++ b/.tekton/openshift-builds-fbc-v4-13-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-13/openshift-builds-fbc-v4-13:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/openshift-builds-fbc-v4-14-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-v4-14-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-14/openshift-builds-fbc-v4-14:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/openshift-builds-fbc-v4-14-push.yaml
+++ b/.tekton/openshift-builds-fbc-v4-14-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-14/openshift-builds-fbc-v4-14:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/openshift-builds-fbc-v4-15-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-v4-15-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-15/openshift-builds-fbc-v4-15:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/openshift-builds-fbc-v4-15-push.yaml
+++ b/.tekton/openshift-builds-fbc-v4-15-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-15/openshift-builds-fbc-v4-15:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/openshift-builds-fbc-v4-16-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-v4-16-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-16/openshift-builds-fbc-v4-16:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/openshift-builds-fbc-v4-16-push.yaml
+++ b/.tekton/openshift-builds-fbc-v4-16-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-16/openshift-builds-fbc-v4-16:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/openshift-builds-fbc-v4-17-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-v4-17-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-17/openshift-builds-fbc-v4-17:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/openshift-builds-fbc-v4-17-push.yaml
+++ b/.tekton/openshift-builds-fbc-v4-17-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds/openshift-builds-catalog:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-v4-17/openshift-builds-fbc-v4-17:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/catalog/v4.17/Dockerfile
+++ b/catalog/v4.17/Dockerfile
@@ -1,6 +1,7 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
+# v4.17 image is not available at this moment, using v4.16
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Changes:
- Fix image repositories
- Change base image in v4.17 docker file to v4.16