### PR TITLE
fix: Add OLM channel for minor versions

### DIFF
--- a/catalog/v4.12/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.12/openshift-builds-operator/catalog.yaml
@@ -4,18 +4,51 @@ name: openshift-builds-operator
 schema: olm.package
 ---
 entries:
-- name: openshift-builds-operator.v1.0.0
-- name: openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.1.0
-  replaces: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+    - openshift-builds-operator.v1.0.0
+    - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
 name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
 package: openshift-builds-operator
 schema: olm.channel
 ---

--- a/catalog/v4.13/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.13/openshift-builds-operator/catalog.yaml
@@ -4,18 +4,51 @@ name: openshift-builds-operator
 schema: olm.package
 ---
 entries:
-- name: openshift-builds-operator.v1.0.0
-- name: openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.1.0
-  replaces: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
 name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
 package: openshift-builds-operator
 schema: olm.channel
 ---

--- a/catalog/v4.14/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.14/openshift-builds-operator/catalog.yaml
@@ -4,18 +4,51 @@ name: openshift-builds-operator
 schema: olm.package
 ---
 entries:
-- name: openshift-builds-operator.v1.0.0
-- name: openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.1.0
-  replaces: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
 name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
 package: openshift-builds-operator
 schema: olm.channel
 ---

--- a/catalog/v4.15/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.15/openshift-builds-operator/catalog.yaml
@@ -4,18 +4,51 @@ name: openshift-builds-operator
 schema: olm.package
 ---
 entries:
-- name: openshift-builds-operator.v1.0.0
-- name: openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.1.0
-  replaces: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
 name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
 package: openshift-builds-operator
 schema: olm.channel
 ---

--- a/catalog/v4.16/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.16/openshift-builds-operator/catalog.yaml
@@ -4,18 +4,51 @@ name: openshift-builds-operator
 schema: olm.package
 ---
 entries:
-- name: openshift-builds-operator.v1.0.0
-- name: openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.1.0
-  replaces: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
 name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
 package: openshift-builds-operator
 schema: olm.channel
 ---

--- a/catalog/v4.17/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.17/openshift-builds-operator/catalog.yaml
@@ -4,18 +4,51 @@ name: openshift-builds-operator
 schema: olm.package
 ---
 entries:
-- name: openshift-builds-operator.v1.0.0
-- name: openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
-- name: openshift-builds-operator.v1.1.0
-  replaces: openshift-builds-operator.v1.0.2
-  skips:
-  - openshift-builds-operator.v1.0.0
-  - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
 name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
 package: openshift-builds-operator
 schema: olm.channel
 ---


### PR DESCRIPTION
Changes:
- Add OLM channel for minor versions, `openshift-builds-1.0` and `openshift-builds-1.1`