### PR TITLE
BUILD-1076: Restore `stable-v1` Channel

### DIFF
--- a/catalog/v4.12/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.12/openshift-builds-operator/catalog.yaml
@@ -1,7 +1,23 @@
 ---
-defaultChannel: latest
+defaultChannel: stable-v1
 name: openshift-builds-operator
 schema: olm.package
+---
+entries:
+- name: openshift-builds-operator.v1.0.0
+- name: openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.1.0
+  replaces: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
 ---
 entries:
 - name: openshift-builds-operator.v1.0.0

--- a/catalog/v4.13/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.13/openshift-builds-operator/catalog.yaml
@@ -1,7 +1,23 @@
 ---
-defaultChannel: latest
+defaultChannel: stable-v1
 name: openshift-builds-operator
 schema: olm.package
+---
+entries:
+- name: openshift-builds-operator.v1.0.0
+- name: openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.1.0
+  replaces: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
 ---
 entries:
 - name: openshift-builds-operator.v1.0.0

--- a/catalog/v4.14/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.14/openshift-builds-operator/catalog.yaml
@@ -1,7 +1,23 @@
 ---
-defaultChannel: latest
+defaultChannel: stable-v1
 name: openshift-builds-operator
 schema: olm.package
+---
+entries:
+- name: openshift-builds-operator.v1.0.0
+- name: openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.1.0
+  replaces: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
 ---
 entries:
 - name: openshift-builds-operator.v1.0.0

--- a/catalog/v4.15/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.15/openshift-builds-operator/catalog.yaml
@@ -1,7 +1,23 @@
 ---
-defaultChannel: latest
+defaultChannel: stable-v1
 name: openshift-builds-operator
 schema: olm.package
+---
+entries:
+- name: openshift-builds-operator.v1.0.0
+- name: openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.1.0
+  replaces: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
 ---
 entries:
 - name: openshift-builds-operator.v1.0.0

--- a/catalog/v4.16/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.16/openshift-builds-operator/catalog.yaml
@@ -1,7 +1,23 @@
 ---
-defaultChannel: latest
+defaultChannel: stable-v1
 name: openshift-builds-operator
 schema: olm.package
+---
+entries:
+- name: openshift-builds-operator.v1.0.0
+- name: openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.1.0
+  replaces: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
 ---
 entries:
 - name: openshift-builds-operator.v1.0.0

--- a/catalog/v4.17/openshift-builds-operator/catalog.yaml
+++ b/catalog/v4.17/openshift-builds-operator/catalog.yaml
@@ -1,7 +1,23 @@
 ---
-defaultChannel: latest
+defaultChannel: stable-v1
 name: openshift-builds-operator
 schema: olm.package
+---
+entries:
+- name: openshift-builds-operator.v1.0.0
+- name: openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+- name: openshift-builds-operator.v1.1.0
+  replaces: openshift-builds-operator.v1.0.2
+  skips:
+  - openshift-builds-operator.v1.0.0
+  - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
 ---
 entries:
 - name: openshift-builds-operator.v1.0.0


### PR DESCRIPTION
Restoring the `stable-v1` channel, which we created as part of the Builds for OpenShift 1.1 release. We cannot remove operator channels without risk of breaking customers who installed Builds for OpenShift on their clusters.

Was removed in #12.