### PR TITLE
Add FBC catalog for OCP 4.18

### DIFF
--- a/.tekton/openshift-builds-fbc-4-18-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-18-pull-request.yaml
@@ -1,0 +1,401 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "main" &&
+      (
+        files.all.exists(x, x.matches('fbc/4.18')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-fbc-4-18-pull-request.yaml'))
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: openshift-builds-fbc-4-18
+    appstudio.openshift.io/component: openshift-builds-fbc-4-18
+    pipelines.appstudio.openshift.io/type: build
+  name: openshift-builds-fbc-4-18-on-pull-request
+  namespace: rh-openshift-builds-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-4-18:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: fbc/4.18
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/arm64
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
+
+      _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+    finally:
+      - name: show-sbom
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+        taskRef:
+          params:
+            - name: name
+              value: show-sbom
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:945a7c9066d3e0a95d3fddb7e8a6992e4d632a2a75d8f3a9bd2ff2fef0ec9aa0
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: show-summary
+        params:
+          - name: pipelinerun-name
+            value: $(context.pipelineRun.name)
+          - name: git-url
+            value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+          - name: image-url
+            value: $(params.output-image)
+          - name: build-task-status
+            value: $(tasks.build-image-index.status)
+        taskRef:
+          params:
+            - name: name
+              value: summary
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: workspace
+            workspace: workspace
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description: Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Force rebuild image
+        name: rebuild
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "true"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched by Cachi2
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+      - default: "true"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: "true"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default:
+          - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
+        description: List of platforms to build the container images on. The available
+          set of values is determined by the configuration of the multi-platform-controller.
+        name: build-platforms
+        type: array
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: image-url
+            value: $(params.output-image)
+          - name: rebuild
+            value: $(params.rebuild)
+          - name: skip-checks
+            value: $(params.skip-checks)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:90dda596d44b3f861889da2fba161dff34c6116fe76c3989e3f84262ea0f29cd
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0cf39c32d86900dce3f7d53f828826dd96ad917c5f4c0b01fb1865346601447d
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - matrix:
+          params:
+            - name: PLATFORM
+              value:
+                - $(params.build-platforms)
+        name: build-images
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: DOCKERFILE
+            value: $(params.dockerfile)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: HERMETIC
+            value: $(params.hermetic)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: buildah-remote-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:f8b47e7205f836bd6fe5920d6c414a7d9a7a18939d167f1c3f5534902f51fd15
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-images.results.IMAGE_REF[*])
+        runAfter:
+          - build-images
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:479775c8655d815fb515aeb97efc0e64284a8520c452754981970900b937a393
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+      - name: deprecated-base-image-check
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: deprecated-image-check
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:f8efb0b22692fad908a1a75f8d5c0b6ed3b0bcd2a9853577e7be275e5bac1bb8
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: apply-tags
+        params:
+          - name: IMAGE
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: apply-tags
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:2c2d88c07623b2d25163994ded6e9f29205ea5bbab090f4c86379739940028b9
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: inspect-image
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: inspect-image
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.2@sha256:8ec039eeaa71e73465ad3a361a81aca1a95d361762e899fde780249948ed8145
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+        workspaces:
+          - name: source
+            workspace: workspace
+      - name: fbc-validate
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: BASE_IMAGE
+            value: $(tasks.inspect-image.results.BASE_IMAGE)
+        runAfter:
+          - inspect-image
+        taskRef:
+          params:
+            - name: name
+              value: fbc-validation
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.2@sha256:1f5e199042025b4a7c0f9e49e09c5b62d2e20c5e1b1457dde9ae2ded77774be4
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+        workspaces:
+          - name: workspace
+            workspace: workspace
+      - name: fbc-related-image-check
+        runAfter:
+          - fbc-validate
+        taskRef:
+          params:
+            - name: name
+              value: fbc-related-image-check
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.2@sha256:f97137a14410d49610fa6961d040c7d55fe1e58d8aaa7c935130e3c5608f2275
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+        workspaces:
+          - name: workspace
+            workspace: workspace
+    workspaces:
+      - name: workspace
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate: {}
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        metadata:
+          creationTimestamp: null
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+        status: {}
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/openshift-builds-fbc-4-18-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-18-push.yaml
@@ -1,0 +1,397 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/redhat-openshift-builds/catalog?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      (
+        files.all.exists(x, x.matches('fbc/4.18')) ||
+        files.all.exists(x, x.matches('.tekton/openshift-builds-fbc-4-18-push.yaml'))
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: openshift-builds-fbc-4-18
+    appstudio.openshift.io/component: openshift-builds-fbc-4-18
+    pipelines.appstudio.openshift.io/type: build
+  name: openshift-builds-fbc-4-18-on-push
+  namespace: rh-openshift-builds-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-builds-fbc-4-18:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: fbc/4.18
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
+
+      _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+    finally:
+      - name: show-sbom
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+        taskRef:
+          params:
+            - name: name
+              value: show-sbom
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:945a7c9066d3e0a95d3fddb7e8a6992e4d632a2a75d8f3a9bd2ff2fef0ec9aa0
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: show-summary
+        params:
+          - name: pipelinerun-name
+            value: $(context.pipelineRun.name)
+          - name: git-url
+            value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+          - name: image-url
+            value: $(params.output-image)
+          - name: build-task-status
+            value: $(tasks.build-image-index.status)
+        taskRef:
+          params:
+            - name: name
+              value: summary
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
+            - name: kind
+              value: task
+          resolver: bundles
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description: Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Force rebuild image
+        name: rebuild
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "true"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched by Cachi2
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+      - default: "true"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: "true"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default:
+          - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
+        description: List of platforms to build the container images on. The available
+          set of values is determined by the configuration of the multi-platform-controller.
+        name: build-platforms
+        type: array
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: image-url
+            value: $(params.output-image)
+          - name: rebuild
+            value: $(params.rebuild)
+          - name: skip-checks
+            value: $(params.skip-checks)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:90dda596d44b3f861889da2fba161dff34c6116fe76c3989e3f84262ea0f29cd
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0cf39c32d86900dce3f7d53f828826dd96ad917c5f4c0b01fb1865346601447d
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - matrix:
+          params:
+            - name: PLATFORM
+              value:
+                - $(params.build-platforms)
+        name: build-images
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: DOCKERFILE
+            value: $(params.dockerfile)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: HERMETIC
+            value: $(params.hermetic)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: buildah-remote-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:f8b47e7205f836bd6fe5920d6c414a7d9a7a18939d167f1c3f5534902f51fd15
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-images.results.IMAGE_REF[*])
+        runAfter:
+          - build-images
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:479775c8655d815fb515aeb97efc0e64284a8520c452754981970900b937a393
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+      - name: deprecated-base-image-check
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: deprecated-image-check
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:f8efb0b22692fad908a1a75f8d5c0b6ed3b0bcd2a9853577e7be275e5bac1bb8
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: apply-tags
+        params:
+          - name: IMAGE
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: apply-tags
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:2c2d88c07623b2d25163994ded6e9f29205ea5bbab090f4c86379739940028b9
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: inspect-image
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: inspect-image
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.2@sha256:8ec039eeaa71e73465ad3a361a81aca1a95d361762e899fde780249948ed8145
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+        workspaces:
+          - name: source
+            workspace: workspace
+      - name: fbc-validate
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: BASE_IMAGE
+            value: $(tasks.inspect-image.results.BASE_IMAGE)
+        runAfter:
+          - inspect-image
+        taskRef:
+          params:
+            - name: name
+              value: fbc-validation
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.2@sha256:1f5e199042025b4a7c0f9e49e09c5b62d2e20c5e1b1457dde9ae2ded77774be4
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+        workspaces:
+          - name: workspace
+            workspace: workspace
+      - name: fbc-related-image-check
+        runAfter:
+          - fbc-validate
+        taskRef:
+          params:
+            - name: name
+              value: fbc-related-image-check
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.2@sha256:f97137a14410d49610fa6961d040c7d55fe1e58d8aaa7c935130e3c5608f2275
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+        workspaces:
+          - name: workspace
+            workspace: workspace
+    workspaces:
+      - name: workspace
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate: {}
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        metadata:
+          creationTimestamp: null
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+        status: {}
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/fbc/4.18/Dockerfile
+++ b/fbc/4.18/Dockerfile
@@ -1,0 +1,18 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+# Using brew.registry.redhat.io instead of registry.redhat.io since 4.18 is not release yet.
+# brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+# registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD openshift-builds-operator /configs/openshift-builds-operator
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/fbc/4.18/openshift-builds-operator/catalog.yaml
+++ b/fbc/4.18/openshift-builds-operator/catalog.yaml
@@ -1,0 +1,764 @@
+---
+defaultChannel: latest
+icon:
+  base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDM4IDM4Ij48ZGVmcz48c3R5bGU+LmN7ZmlsbDojZTAwO30uZHtmaWxsOiNmZmY7fS5le2ZpbGw6I2UwZTBlMDt9PC9zdHlsZT48L2RlZnM+PGcgaWQ9ImEiPjxnPjxyZWN0IGNsYXNzPSJkIiB4PSIxIiB5PSIxIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHJ4PSI5IiByeT0iOSIvPjxwYXRoIGNsYXNzPSJlIiBkPSJNMjgsMi4yNWM0LjI3LDAsNy43NSwzLjQ4LDcuNzUsNy43NVYyOGMwLDQuMjctMy40OCw3Ljc1LTcuNzUsNy43NUgxMGMtNC4yNywwLTcuNzUtMy40OC03Ljc1LTcuNzVWMTBjMC00LjI3LDMuNDgtNy43NSw3Ljc1LTcuNzVIMjhtMC0xLjI1SDEwQzUuMDMsMSwxLDUuMDMsMSwxMFYyOGMwLDQuOTcsNC4wMyw5LDksOUgyOGM0Ljk3LDAsOS00LjAzLDktOVYxMGMwLTQuOTctNC4wMy05LTktOWgwWiIvPjwvZz48L2c+PGcgaWQ9ImIiPjxnPjxjaXJjbGUgY2xhc3M9ImQiIGN4PSIxOSIgY3k9IjE5IiByPSI3LjM4Ii8+PHBhdGggY2xhc3M9ImMiIGQ9Ik0xOSwxMC4zOGMtNC43NiwwLTguNjIsMy44Ny04LjYyLDguNjJzMy44Nyw4LjYyLDguNjIsOC42Miw4LjYyLTMuODcsOC42Mi04LjYyLTMuODctOC42Mi04LjYyLTguNjJabTAsMTZjLTQuMDcsMC03LjM4LTMuMzEtNy4zOC03LjM4czMuMzEtNy4zOCw3LjM4LTcuMzgsNy4zOCwzLjMxLDcuMzgsNy4zOC0zLjMxLDcuMzgtNy4zOCw3LjM4WiIvPjwvZz48Zz48cGF0aCBjbGFzcz0iZCIgZD0iTTE1LjM4LDE2YzAtLjM1LC4yOC0uNjIsLjYyLS42Mmg1LjM4di00Ljc1SDEwLjYydjEwLjc1aDQuNzV2LTUuMzhaIi8+PHJlY3QgY2xhc3M9ImQiIHg9IjE2LjYyIiB5PSIxNi42MiIgd2lkdGg9IjEwLjc1IiBoZWlnaHQ9IjEwLjc1Ii8+PHBhdGggZD0iTTI4LDE1LjM4aC01LjM4di01LjM4YzAtLjM1LS4yOC0uNjItLjYyLS42MkgxMGMtLjM1LDAtLjYyLC4yOC0uNjIsLjYydjEyYzAsLjM1LC4yOCwuNjIsLjYyLC42Mmg1LjM4djUuMzhjMCwuMzUsLjI4LC42MiwuNjIsLjYyaDEyYy4zNCwwLC42Mi0uMjgsLjYyLS42MnYtMTJjMC0uMzUtLjI4LS42Mi0uNjItLjYyWm0tLjYyLDEyaC0xMC43NXYtMTAuNzVoMTAuNzV2MTAuNzVaTTEwLjYyLDEwLjYyaDEwLjc1djQuNzVoLTUuMzhjLS4zNSwwLS42MiwuMjgtLjYyLC42MnY1LjM4aC00Ljc1VjEwLjYyWiIvPjwvZz48Zz48cG9seWdvbiBjbGFzcz0iZCIgcG9pbnRzPSIxOS44OCAyMiAyMSAyMy4xMiAyMSAyMC44OCAxOS44OCAyMiIvPjxwYXRoIGNsYXNzPSJjIiBkPSJNMjEsMjAuODhsLjQ0LS40NGMuMjQtLjI0LC4yNC0uNjQsMC0uODgtLjI0LS4yNC0uNjQtLjI0LS44OCwwbC0yLDJjLS4yNCwuMjQtLjI0LC42NCwwLC44OGwyLDJjLjEyLC4xMiwuMjgsLjE4LC40NCwuMThzLjMyLS4wNiwuNDQtLjE4Yy4yNC0uMjQsLjI0LS42NCwwLS44OGwtLjQ0LS40NC0xLjEyLTEuMTIsMS4xMi0xLjEyWiIvPjxwb2x5Z29uIGNsYXNzPSJkIiBwb2ludHM9IjIzIDIwLjg4IDIzIDIzLjEyIDI0LjEyIDIyIDIzIDIwLjg4Ii8+PHBhdGggY2xhc3M9ImMiIGQ9Ik0yNS40NCwyMS41NmwtMi0yYy0uMjQtLjI0LS42NC0uMjQtLjg4LDAtLjI0LC4yNC0uMjQsLjY0LDAsLjg4bC40NCwuNDQsMS4xMiwxLjEyLTEuMTIsMS4xMi0uNDQsLjQ0Yy0uMjQsLjI0LS4yNCwuNjQsMCwuODgsLjEyLC4xMiwuMjgsLjE4LC40NCwuMThzLjMyLS4wNiwuNDQtLjE4bDItMmMuMjQtLjI0LC4yNC0uNjQsMC0uODhaIi8+PC9nPjwvZz48L3N2Zz4=
+  mediatype: image/svg+xml
+name: openshift-builds-operator
+schema: olm.package
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.2.0
+    replaces: openshift-builds-operator.v1.1.0
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+      - openshift-builds-operator.v1.1.0
+name: latest
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.1.0
+    replaces: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: stable-v1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.2.0
+name: builds-1.2
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.1.0
+name: builds-1.1
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
+  - name: openshift-builds-operator.v1.0.0
+  - name: openshift-builds-operator.v1.0.1
+  - name: openshift-builds-operator.v1.0.2
+    skips:
+      - openshift-builds-operator.v1.0.0
+      - openshift-builds-operator.v1.0.1
+name: openshift-builds-1.0
+package: openshift-builds-operator
+schema: olm.channel
+---
+schema: olm.deprecations
+package: openshift-builds-operator
+entries:
+  - reference:
+      schema: olm.bundle
+      name: openshift-builds-operator.v1.0.0
+    message: |
+      openshift-builds-operator.v1.0.0 has reached the end of maintenance support. Please upgrade to openshift-builds-operator.v1.1.0 or later.
+  - reference:
+      schema: olm.bundle
+      name: openshift-builds-operator.v1.0.1
+    message: |
+      openshift-builds-operator.v1.0.1 has reached the end of maintenance support. Please upgrade to openshift-builds-operator.v1.1.0 or later.
+  - reference:
+      schema: olm.bundle
+      name: openshift-builds-operator.v1.0.2
+    message: |
+      openshift-builds-operator.v1.0.2 is deprecated and will reach end of maintenance support soon. Please upgrade to openshift-builds-operator.v1.1.0 or later.
+  - reference:
+      schema: olm.channel
+      name: stable-v1
+    message: |
+      channel 'stable-v1' is deprecated and will reach end of maintenance support soon. Please switch to channel 'latest', 'builds-1.1' or later.
+  - reference:
+      schema: olm.channel
+      name: openshift-builds-1.0
+    message: |
+      channel 'openshift-builds-1.0' is deprecated and will reach end of maintenance support soon. Please switch to channel 'latest', 'builds-1.1' or later.
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:7396a2b15e1674cdf447889a336cadc2b9a3d292a201c04f310bd10b9d4088b6
+name: openshift-builds-operator.v1.0.0
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.0.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "openshift-builds"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:8da190368d4473b80f906f0a9eda334ab61b7123a35aab485d2cff519c0ecbba
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n\n## Usage\n\nTo deploy and manage [builds for Red Hat OpenShift](https://github.com/shipwright-io/build) in your cluster,\nfirst make sure this operator is installed and running on your cluster.\n\nNext, create the following:\n\n```yaml\n---\napiVersion: operator.shipwright.io/v1alpha1\nkind: ShipwrightBuild\nmetadata:\n  name: openshift-builds-operator\nspec:\n  targetNamespace: openshift-builds\n```\n\nThe operator will deploy Shipwright Build in the provided `targetNamespace`.\nWhen `.spec.targetNamespace` is not set, the namespace will default to ` openshift-builds`.\nRefer to the [ShipwrightBuild operator documentation](https://github.com/shipwright-io/operator/blob/main/docs/shipwrightbuild.md) for more information about this custom resource.\n"
+      displayName: builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://shipwright.io
+        - name: Shipwright Builds
+          url: https://github.com/shipwright-io/build
+      maintainers:
+        - email: pipeline-integrations-team@redhat.com
+          name: Red Hat Pipelines Integration Team
+      maturity: alpha
+      minKubeVersion: 1.24.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com/
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel8@sha256:5302d798fc09c43a9f1df7976b0294aca793e3f3fd2df79337e24a0702fa9b20
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel8@sha256:942015a6e38a3258d6ca342d2e427b08c7597960af338e51a6e05015a9800392
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel8@sha256:96366b52047dd856cff57079aeec055149eaf7896f41a1018b667a142c49029c
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel8@sha256:9b26dd91c97579d401a9974492fee38021e08436562d7f9215fe5aeb127cbe73
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:7396a2b15e1674cdf447889a336cadc2b9a3d292a201c04f310bd10b9d4088b6
+    name: ""
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:8da190368d4473b80f906f0a9eda334ab61b7123a35aab485d2cff519c0ecbba
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-triggers-rhel8@sha256:59ac9a99f2cb43322a4731706d1299c95aba8f264bac30d3baf6c47f4809ba49
+    name: OPENSHIFT_BUILDS_TRIGGERS
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel8@sha256:4440b1331edebd617d406fd55e96cfd7672c0610ebdd31cb2f6b5c553fe58567
+    name: OPENSHIFT_BUILDS_WAITERS
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel8@sha256:7ed398c61492a05eaecc580bbb08144f0c850e70b1e236453779cb71f261def7
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
+    name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:56c474f8bc49060c3f1a6fc19d5984b2bbf81ac3ab76a80ce63faa9010d0759f
+name: openshift-builds-operator.v1.0.1
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.0.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "openshift-builds"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:7b6eec6c0df901b69f48be3f023f2de03f374d962bab37e1bd03fc0b9e98aa1f
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n\n## Usage\n\nTo deploy and manage [builds for Red Hat OpenShift](https://github.com/shipwright-io/build) in your cluster,\nfirst make sure this operator is installed and running on your cluster.\n\nNext, create the following:\n\n```yaml\n---\napiVersion: operator.shipwright.io/v1alpha1\nkind: ShipwrightBuild\nmetadata:\n  name: openshift-builds-operator\nspec:\n  targetNamespace: openshift-builds\n```\n\nThe operator will deploy Shipwright Build in the provided `targetNamespace`.\nWhen `.spec.targetNamespace` is not set, the namespace will default to ` openshift-builds`.\nRefer to the [ShipwrightBuild operator documentation](https://github.com/shipwright-io/operator/blob/main/docs/shipwrightbuild.md) for more information about this custom resource.\n"
+      displayName: builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://shipwright.io
+        - name: Shipwright Builds
+          url: https://github.com/shipwright-io/build
+      maintainers:
+        - email: pipeline-integrations-team@redhat.com
+          name: Red Hat Pipelines Integration Team
+      maturity: alpha
+      minKubeVersion: 1.24.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com/
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel8@sha256:b02a6a83737184cfad9390b925df22b0a3c9b3ec14fadca246d55a8d5c800894
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel8@sha256:3869447f8677a07fdbbb42cbad5fcb23a9aa1d99470951de3e2a37c429d90e59
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel8@sha256:bb78ccb00377b3dd271ca43c81245ab4af6fa9032436e5a39d3e277d9e22243a
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel8@sha256:6bd2bde6826c0d417c3b8cffd7b5a6b7ebaf937183e5402173ca3db8bbb2fe88
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:56c474f8bc49060c3f1a6fc19d5984b2bbf81ac3ab76a80ce63faa9010d0759f
+    name: ""
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:7b6eec6c0df901b69f48be3f023f2de03f374d962bab37e1bd03fc0b9e98aa1f
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel8@sha256:aee68d0ea5631a6543a26fe1646a369dd509005be200d49505891bd0c944efa0
+    name: OPENSHIFT_BUILDS_WAITERS
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel8@sha256:426e08f5aef30b7018240f5a03290b085a9f4784a2f04b98fcbe708fa0ac9ee1
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
+    name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:d098d7a51bf3bf5b4c4e27bb570069e4f3e9c897b731ccc8d3a04f5aba77e448
+name: openshift-builds-operator.v1.0.2
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.0.2
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "openshift-builds"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        containerImage: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:7100a83aa053a976ceb77ace79f090ec8601bc9b2152ff6f7d00f0b1deea7f0b
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/disconnected: "false"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n\n## Usage\n\nTo deploy and manage [builds for Red Hat OpenShift](https://github.com/shipwright-io/build) in your cluster,\nfirst make sure this operator is installed and running on your cluster.\n\nNext, create the following:\n\n```yaml\n---\napiVersion: operator.shipwright.io/v1alpha1\nkind: ShipwrightBuild\nmetadata:\n  name: openshift-builds-operator\nspec:\n  targetNamespace: openshift-builds\n```\n\nThe operator will deploy Shipwright Build in the provided `targetNamespace`.\nWhen `.spec.targetNamespace` is not set, the namespace will default to ` openshift-builds`.\nRefer to the [ShipwrightBuild operator documentation](https://github.com/shipwright-io/operator/blob/main/docs/shipwrightbuild.md) for more information about this custom resource.\n"
+      displayName: builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://shipwright.io
+        - name: Shipwright Builds
+          url: https://github.com/shipwright-io/build
+      maintainers:
+        - email: pipeline-integrations-team@redhat.com
+          name: Red Hat Pipelines Integration Team
+      maturity: alpha
+      minKubeVersion: 1.24.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com/
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel8@sha256:0cf079a24b8b3a4b3e1f30710fea85039d9cf323cfedd06e7d1e33e6336fb848
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel8@sha256:22930726a25b11de2571da0395b53352939d142a16f4db6fd5460abd4cc37ba5
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel8@sha256:f95348e5fc48676d93ebc919af2c27a041dfd632ec285296246d886daab11576
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel8@sha256:fd903804672ec08acf9a2b49aa7ecc5f9b543c12f7462637ef756733171b3817
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:d098d7a51bf3bf5b4c4e27bb570069e4f3e9c897b731ccc8d3a04f5aba77e448
+    name: ""
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:7100a83aa053a976ceb77ace79f090ec8601bc9b2152ff6f7d00f0b1deea7f0b
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel8@sha256:d01c1749ce76dd4bf5fefaa6c553725d33533d6e70e884e916f12217b674c3cf
+    name: OPENSHIFT_BUILDS_WAITERS
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel8@sha256:73efcb6ad82f698d7463718b06c86f2b2b3b5326689a62dc39c9f5d68f8943f2
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
+    name: ""
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:42d06f8b7d7ba8f527141ab2f8c0573d081f7257d0ed237e7341bd4f6c218e57
+name: openshift-builds-operator.v1.1.0
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.openshift.io
+      kind: OpenShiftBuild
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.1.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.openshift.io/v1alpha1",
+              "kind": "OpenShiftBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "sharedResource": {
+                  "state": "Enabled"
+                },
+                "shipwright": {
+                  "build": {
+                    "state": "Enabled"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
+        createdAt: "2024-07-31T14:26:32Z"
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "true"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/suggested-namespace: openshift-builds
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.35.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+            displayName: Open Shift Build
+            kind: OpenShiftBuild
+            name: openshiftbuilds.operator.openshift.io
+            version: v1alpha1
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
+      displayName: Builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html
+        - name: Builds for Openshift
+          url: https://github.com/redhat-openshift-builds/operator
+      maintainers:
+        - email: openshift-builds@redhat.com
+          name: Red Hat OpenShift Builds Team
+      maturity: stable
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:a911fd84b3d9bf2ec221660507f4f234ec1ecfc232e9a511a4bd18a2598783df
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:f9494f1408db4fe36e3ddd5bb5c6ca97aec4468e1efbd423c5a4d3f43dd5f7ab
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:aebf65b8c3a83ba4b5e7a8b36e90b6bdf220c5528039ec0310f363a4dea0d54f
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:7bbe8727e99c99eae5a269a3e1e5296c1bf1b1750bd014fabafbc545da2da2a7
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:42d06f8b7d7ba8f527141ab2f8c0573d081f7257d0ed237e7341bd4f6c218e57
+    name: ""
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:3ecc42df618054809d79f60de80b258a69ca25c66e43f9f2a879e3ce6b840f03
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:20152a6ef899664e732baba74782938c312397d08c8670a4e3ce657a78284b35
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:599d8e8f2695e8a285bf62af3ba26b250d0766f63258edaed7f82f6b30bdff4a
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:4bd4dbe6aa6c06551763738b24c43e992b336dfae6c05728fc980ee0291b0ac6
+    name: OPENSHIFT_BUILDS_WAITER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:d997fe638a6b6129ff310dff743da52d08abb263a90404f61f33fb999eda4e77
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar@sha256:98341f0b80eeb6064540b61626acb6c6772c1e5c6991b67cfec3768cf459da14
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:cdfbad6599b109f1f307e3c34da50878b6b8df69e8cfffe34bd191d57354bddd
+name: openshift-builds-operator.v1.2.0
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.openshift.io
+      kind: OpenShiftBuild
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.2.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.openshift.io/v1alpha1",
+              "kind": "OpenShiftBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "sharedResource": {
+                  "state": "Enabled"
+                },
+                "shipwright": {
+                  "build": {
+                    "state": "Enabled"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
+        createdAt: "2024-11-15T22:28:01Z"
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "true"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "true"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/suggested-namespace: openshift-builds
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.35.0
+        operators.operatorframework.io/internal-objects: '["openshiftbuilds.operator.openshift.io","shipwrightbuilds.operator.shipwright.io"]'
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+            displayName: Open Shift Build
+            kind: OpenShiftBuild
+            name: openshiftbuilds.operator.openshift.io
+            version: v1alpha1
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
+      displayName: Builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.2
+        - name: Builds for Openshift
+          url: https://github.com/redhat-openshift-builds/operator
+      maintainers:
+        - email: support@redhat.com
+          name: Red Hat OpenShift Builds Team
+      maturity: stable
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:540974bc3ecbbea131ea555c61a064917d897d814bcb20f8b2ec111e0709a059
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:9652607c0639c9c5479fff0094a8be7b296b92e44f7500783c4519fd110e0b7d
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:2e713df571118f108bd3e6c4a1c6ba575765f926b3c7ac77a6be7d438811fd9b
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:6f7e6789f38600eebc1ea24a38557311274135589ac558ddbc8d4af71d293101
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:cdfbad6599b109f1f307e3c34da50878b6b8df69e8cfffe34bd191d57354bddd
+    name: ""
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:10e6f445071e25ae2bba88e539869874525456dcf9f3751de604b915e8b70333
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:4360777eae5222b4828dec01591520c500e3c8db8fe7d28168b231e7ad724336
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:5dfcf358e80344d226a4037174ea3e8a68c7640051538b235cf23b64cb5b1ba9
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:b58242d654b67f71844e2dec00506651496381fe9a173e9c719086c7d9519ab6
+    name: OPENSHIFT_BUILDS_WAITER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:3ce032366c007a161a2fd92d68dc12c123b57693fa974c92aaec9c13ca63cccc
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:8520421013d374cb94610941f0f4358817a8339fbdb6bc24a3acda0a52a2748f
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fa22124916523b958c67af8ad652e73a2c3d68bb5579da1cba1ade537f3b7ae
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
+  - image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:d041c1bbe503d152d0759598f79802e257816d674b342670ef61c6f9e6d401c5
+    name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
+  - image: registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e
+    name: OPENSHIFT_BUILDS_BUILDAH
+schema: olm.bundle


### PR DESCRIPTION
Changes:
- Add FBC catalog for OCP 4.18

Note:
- brew.registry.redhat.io is used because OCP 4.18 is not released yet.