### PR TITLE
Fix: Revert CycloneDX from 1.6 to 1.5

### DIFF
--- a/.tekton/openshift-builds-fbc-4-12-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-12-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-12-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-12-push.yaml
@@ -225,7 +225,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-13-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-13-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-13-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-13-push.yaml
@@ -225,7 +225,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-14-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-14-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-14-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-14-push.yaml
@@ -225,7 +225,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-15-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-15-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-15-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-15-push.yaml
@@ -225,7 +225,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-16-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-16-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-16-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-16-push.yaml
@@ -225,7 +225,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-17-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-17-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/openshift-builds-fbc-4-17-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-17-push.yaml
@@ -225,7 +225,7 @@ spec:
             - name: name
               value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Changes:
- Revert task-buildah-remote-oci-ta to older version to use CycloneDX 1.5, as it is causing issue in Konflux pipeline.