### PR TITLE
Add builds-1.3 entries to 4.18 registry

### DIFF
--- a/fbc/4.18/Dockerfile
+++ b/fbc/4.18/Dockerfile
@@ -3,7 +3,7 @@
 # Using brew.registry.redhat.io instead of registry.redhat.io since 4.18 is not release yet.
 # brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
 # registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/fbc/4.18/openshift-builds-operator/catalog.yaml
+++ b/fbc/4.18/openshift-builds-operator/catalog.yaml
@@ -14,16 +14,17 @@ entries:
       - openshift-builds-operator.v1.0.0
       - openshift-builds-operator.v1.0.1
   - name: openshift-builds-operator.v1.1.0
+  - name: openshift-builds-operator.v1.1.1
     replaces: openshift-builds-operator.v1.0.2
     skips:
-      - openshift-builds-operator.v1.0.0
-      - openshift-builds-operator.v1.0.1
-  - name: openshift-builds-operator.v1.2.0
-    replaces: openshift-builds-operator.v1.1.0
-    skips:
-      - openshift-builds-operator.v1.0.0
-      - openshift-builds-operator.v1.0.1
       - openshift-builds-operator.v1.1.0
+  - name: openshift-builds-operator.v1.2.0
+  - name: openshift-builds-operator.v1.2.1
+    replaces: openshift-builds-operator.v1.1.1
+    skips:
+      - openshift-builds-operator.v1.2.0
+  - name: openshift-builds-operator.v1.3.0
+    replaces: openshift-builds-operator.v1.2.1
 name: latest
 package: openshift-builds-operator
 schema: olm.channel
@@ -36,22 +37,42 @@ entries:
       - openshift-builds-operator.v1.0.0
       - openshift-builds-operator.v1.0.1
   - name: openshift-builds-operator.v1.1.0
+  - name: openshift-builds-operator.v1.1.1
     replaces: openshift-builds-operator.v1.0.2
     skips:
-      - openshift-builds-operator.v1.0.0
-      - openshift-builds-operator.v1.0.1
+      - openshift-builds-operator.v1.0.2
+      - openshift-builds-operator.v1.1.0
+  - name: openshift-builds-operator.v1.2.0
+  - name: openshift-builds-operator.v1.2.1
+    replaces: openshift-builds-operator.v1.1.1
+    skips:
+      - openshift-builds-operator.v1.0.2
+      - openshift-builds-operator.v1.1.1
+      - openshift-builds-operator.v1.2.0
 name: stable-v1
 package: openshift-builds-operator
 schema: olm.channel
 ---
 entries:
+  - name: openshift-builds-operator.v1.3.0
+name: builds-1.3
+package: openshift-builds-operator
+schema: olm.channel
+---
+entries:
   - name: openshift-builds-operator.v1.2.0
+  - name: openshift-builds-operator.v1.2.1
+    skips:
+      - openshift-builds-operator.v1.2.0
 name: builds-1.2
 package: openshift-builds-operator
 schema: olm.channel
 ---
 entries:
   - name: openshift-builds-operator.v1.1.0
+  - name: openshift-builds-operator.v1.1.1
+    skips:
+      - openshift-builds-operator.v1.1.0
 name: builds-1.1
 package: openshift-builds-operator
 schema: olm.channel
@@ -95,6 +116,21 @@ entries:
       name: openshift-builds-1.0
     message: |
       channel 'openshift-builds-1.0' is deprecated and will reach end of maintenance support soon. Please switch to channel 'latest', 'builds-1.1' or later.
+  - reference:
+      schema: olm.bundle
+      name: openshift-builds-operator.v1.1.0
+    message: |
+      openshift-builds-operator.v1.1.0 has reached the end of maintenance support. Please upgrade to openshift-builds-operator.v1.2.0 or later.
+  - reference:
+      schema: olm.bundle
+      name: openshift-builds-operator.v1.1.1
+    message: |
+      openshift-builds-operator.v1.1.1 has reached the end of maintenance support. Please upgrade to openshift-builds-operator.v1.2.0 or later.
+  - reference:
+      schema: olm.channel
+      name: builds-1.1
+    message: |
+      channel 'openshift-builds-1.1' is deprecated and will reach end of maintenance support soon. Please switch to channel 'latest', 'builds-1.2' or later.
 ---
 image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:7396a2b15e1674cdf447889a336cadc2b9a3d292a201c04f310bd10b9d4088b6
 name: openshift-builds-operator.v1.0.0
@@ -197,7 +233,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel8@sha256:9b26dd91c97579d401a9974492fee38021e08436562d7f9215fe5aeb127cbe73
     name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
   - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:7396a2b15e1674cdf447889a336cadc2b9a3d292a201c04f310bd10b9d4088b6
-    name: ""
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
   - image: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:8da190368d4473b80f906f0a9eda334ab61b7123a35aab485d2cff519c0ecbba
     name: OPENSHIFT_BUILDS_OPERATOR
   - image: registry.redhat.io/openshift-builds/openshift-builds-triggers-rhel8@sha256:59ac9a99f2cb43322a4731706d1299c95aba8f264bac30d3baf6c47f4809ba49
@@ -207,7 +243,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel8@sha256:7ed398c61492a05eaecc580bbb08144f0c850e70b1e236453779cb71f261def7
     name: OPENSHIFT_BUILDS_WEBHOOK
   - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
-    name: ""
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
 schema: olm.bundle
 ---
 image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:56c474f8bc49060c3f1a6fc19d5984b2bbf81ac3ab76a80ce63faa9010d0759f
@@ -317,7 +353,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel8@sha256:6bd2bde6826c0d417c3b8cffd7b5a6b7ebaf937183e5402173ca3db8bbb2fe88
     name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
   - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:56c474f8bc49060c3f1a6fc19d5984b2bbf81ac3ab76a80ce63faa9010d0759f
-    name: ""
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
   - image: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:7b6eec6c0df901b69f48be3f023f2de03f374d962bab37e1bd03fc0b9e98aa1f
     name: OPENSHIFT_BUILDS_OPERATOR
   - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel8@sha256:aee68d0ea5631a6543a26fe1646a369dd509005be200d49505891bd0c944efa0
@@ -325,7 +361,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel8@sha256:426e08f5aef30b7018240f5a03290b085a9f4784a2f04b98fcbe708fa0ac9ee1
     name: OPENSHIFT_BUILDS_WEBHOOK
   - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
-    name: ""
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
 schema: olm.bundle
 ---
 image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:d098d7a51bf3bf5b4c4e27bb570069e4f3e9c897b731ccc8d3a04f5aba77e448
@@ -435,7 +471,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel8@sha256:fd903804672ec08acf9a2b49aa7ecc5f9b543c12f7462637ef756733171b3817
     name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
   - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:d098d7a51bf3bf5b4c4e27bb570069e4f3e9c897b731ccc8d3a04f5aba77e448
-    name: ""
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
   - image: registry.redhat.io/openshift-builds/openshift-builds-rhel8-operator@sha256:7100a83aa053a976ceb77ace79f090ec8601bc9b2152ff6f7d00f0b1deea7f0b
     name: OPENSHIFT_BUILDS_OPERATOR
   - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel8@sha256:d01c1749ce76dd4bf5fefaa6c553725d33533d6e70e884e916f12217b674c3cf
@@ -443,7 +479,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel8@sha256:73efcb6ad82f698d7463718b06c86f2b2b3b5326689a62dc39c9f5d68f8943f2
     name: OPENSHIFT_BUILDS_WEBHOOK
   - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
-    name: ""
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
 schema: olm.bundle
 ---
 image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:42d06f8b7d7ba8f527141ab2f8c0573d081f7257d0ed237e7341bd4f6c218e57
@@ -585,7 +621,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:7bbe8727e99c99eae5a269a3e1e5296c1bf1b1750bd014fabafbc545da2da2a7
     name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
   - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:42d06f8b7d7ba8f527141ab2f8c0573d081f7257d0ed237e7341bd4f6c218e57
-    name: ""
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
   - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:3ecc42df618054809d79f60de80b258a69ca25c66e43f9f2a879e3ce6b840f03
     name: OPENSHIFT_BUILDS_OPERATOR
   - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:20152a6ef899664e732baba74782938c312397d08c8670a4e3ce657a78284b35
@@ -742,7 +778,7 @@ relatedImages:
   - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:6f7e6789f38600eebc1ea24a38557311274135589ac558ddbc8d4af71d293101
     name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
   - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:cdfbad6599b109f1f307e3c34da50878b6b8df69e8cfffe34bd191d57354bddd
-    name: ""
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
   - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:10e6f445071e25ae2bba88e539869874525456dcf9f3751de604b915e8b70333
     name: OPENSHIFT_BUILDS_OPERATOR
   - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:4360777eae5222b4828dec01591520c500e3c8db8fe7d28168b231e7ad724336
@@ -760,5 +796,483 @@ relatedImages:
   - image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:d041c1bbe503d152d0759598f79802e257816d674b342670ef61c6f9e6d401c5
     name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
   - image: registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e
+    name: OPENSHIFT_BUILDS_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:6c7a737b62c2e368732d80287c96f70442f3949d8b6a0e7d4b5f8afa596384ec
+name: openshift-builds-operator.v1.1.1
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.openshift.io
+      kind: OpenShiftBuild
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.1.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.openshift.io/v1alpha1",
+              "kind": "OpenShiftBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "sharedResource": {
+                  "state": "Enabled"
+                },
+                "shipwright": {
+                  "build": {
+                    "state": "Enabled"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        createdAt: "2025-01-23T14:48:43Z"
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "true"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "false"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/suggested-namespace: openshift-builds
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.35.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+            displayName: Open Shift Build
+            kind: OpenShiftBuild
+            name: openshiftbuilds.operator.openshift.io
+            version: v1alpha1
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
+      displayName: Builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html
+        - name: Builds for Openshift
+          url: https://github.com/redhat-openshift-builds/operator
+      maintainers:
+        - email: openshift-builds@redhat.com
+          name: Red Hat OpenShift Builds Team
+      maturity: stable
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:5babdf590730b217deb59acbccf142c0500bc692542131810714cc00724ee02c
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:0e139db4370c37e91ef7eb3e0cf9a2587cb81f37709009a37f2724d4461ed2f3
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:7cfffdd43fdd33a20d115f35c2ba492da3c1d0e3ab970587bc888c68c47dfacf
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:949a1a5150642167b6c7d2b8f6d92a2885afe453319c02495f351b2e79eff3dd
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:6c7a737b62c2e368732d80287c96f70442f3949d8b6a0e7d4b5f8afa596384ec
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:e9f7b8741f265a332008424a2c5b3dae9ea154e623c469085c2abafb53fc62d4
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:1ec9a1dcfc08b707df48175bba76f8a6cbfcc8396d9e9940cc3d7100e6731701
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:5ec474ab9e62c92e44c1a6635913032aead6246faec0895dcfbdb28ab0dc8a1a
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:778ad1946bdad68e1430a2fb366cee25cd98d87e44cf5ad34b87603c2f4171d0
+    name: OPENSHIFT_BUILDS_WAITER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:fa039b62ebd1fc6e86db8ec1c7ae5fe0dd3a6f6f642b63b4dc89af32a78cea6b
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:e8582857566020c71653228355cbadc2c1cda41e36fc767c204a4edb05e7f42a
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:97cade2c1ee468261aec5400728c8d44de387b459134aec7a4c3b5ec5a335d2c
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:db0cb578c2bdd56bea08e7eaf9db555f78653519714bf077b2a7efa052ef792f
+name: openshift-builds-operator.v1.2.1
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.openshift.io
+      kind: OpenShiftBuild
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.2.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.openshift.io/v1alpha1",
+              "kind": "OpenShiftBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "sharedResource": {
+                  "state": "Enabled"
+                },
+                "shipwright": {
+                  "build": {
+                    "state": "Enabled"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        createdAt: "2025-01-23T13:47:38Z"
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "true"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "true"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/suggested-namespace: openshift-builds
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.35.0
+        operators.operatorframework.io/internal-objects: '["openshiftbuilds.operator.openshift.io","shipwrightbuilds.operator.shipwright.io"]'
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+            displayName: Open Shift Build
+            kind: OpenShiftBuild
+            name: openshiftbuilds.operator.openshift.io
+            version: v1alpha1
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
+      displayName: Builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.2
+        - name: Builds for Openshift
+          url: https://github.com/redhat-openshift-builds/operator
+      maintainers:
+        - email: support@redhat.com
+          name: Red Hat OpenShift Builds Team
+      maturity: stable
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:8ff35f843458754b75d8fb5b554c174be72a4eba043aa7b4e44adfe119d3a1e0
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:fc187ff9aa8375fe65ac64388563ff522e4aa1ba8cd69485c390090e924ef006
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:c4e0b8b8b1b4c28e642f2fd35d822a740fb3378a0bd75380cf4c6367c92028c4
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:1064515dc5e61b444dcab6fae0a0757331a4b4cf1af088c5361c9974fc97ed29
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:db0cb578c2bdd56bea08e7eaf9db555f78653519714bf077b2a7efa052ef792f
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:1f4bb11f97158b3a4fe0aa34eca7ec7e9e568c42e559e9c1864c0586504a51d1
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:56b92b7fa0ea54e64ed7b71990ed41b4f47fe77af9fe80f6ebc8f11fba5b23e8
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:b900e8001bcf444a395b212eb767462c32bb646ebe1dbc4dae7b437779b5b344
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:c69f046a0c27c6e388be6d86e7237452ab620350b7488559d448f9dd923b41b1
+    name: OPENSHIFT_BUILDS_WAITER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:576d8638970f6bcce3954af8fdb319ef47cf27169945748369c0a753a34de5c1
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:e8582857566020c71653228355cbadc2c1cda41e36fc767c204a4edb05e7f42a
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fa22124916523b958c67af8ad652e73a2c3d68bb5579da1cba1ade537f3b7ae
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fcd8e2bf0bcb8ff8c93a87af2c59a3bcae7be8792f9d3236c9b5bbd9b6db3b2
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
+  - image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:016c93578908f1dbdc3052333a1d5a9ab0c03104070ac36a6ddf99350d7510f4
+    name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
+  - image: registry.redhat.io/ubi8/buildah@sha256:56c71ecd450f284325ba8434cbf5b3006078b11f0625c6258689699fa811c95d
+    name: OPENSHIFT_BUILDS_BUILDAH
+schema: olm.bundle
+---
+image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:29177a9d6cab538e97d35a0aff6aed31cebd068a34b49884dbab7af9d158ea48
+name: openshift-builds-operator.v1.3.0
+package: openshift-builds-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: operator.openshift.io
+      kind: OpenShiftBuild
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: operator.shipwright.io
+      kind: ShipwrightBuild
+      version: v1alpha1
+  - type: olm.gvk.required
+    value:
+      group: operator.tekton.dev
+      kind: TektonConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: openshift-builds-operator
+      version: 1.3.0
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "operator.openshift.io/v1alpha1",
+              "kind": "OpenShiftBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "sharedResource": {
+                  "state": "Enabled"
+                },
+                "shipwright": {
+                  "build": {
+                    "state": "Enabled"
+                  }
+                }
+              }
+            },
+            {
+              "apiVersion": "operator.shipwright.io/v1alpha1",
+              "kind": "ShipwrightBuild",
+              "metadata": {
+                "name": "cluster"
+              },
+              "spec": {
+                "targetNamespace": "openshift-builds"
+              }
+            }
+          ]
+        capabilities: Full Lifecycle
+        categories: Developer Tools, Integration & Delivery
+        certified: "true"
+        containerImage: registry.redhat.io/openshift-builds/openshift-builds-operator-rhel9
+        createdAt: "2025-01-29T08:58:54Z"
+        description: Builds for Red Hat OpenShift is a framework for building container images on Kubernetes.
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "true"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "false"
+        features.operators.openshift.io/proxy-aware: "true"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/suggested-namespace: openshift-builds
+        operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.35.0
+        operators.operatorframework.io/internal-objects: '["openshiftbuilds.operator.openshift.io","shipwrightbuilds.operator.shipwright.io"]'
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/shipwright-io/operator
+        support: Red Hat
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: OpenShiftBuild describes the desired state of Builds for OpenShift, and the status of all deployed components.
+            displayName: Open Shift Build
+            kind: OpenShiftBuild
+            name: openshiftbuilds.operator.openshift.io
+            version: v1alpha1
+          - description: ShipwrightBuild represents the deployment of Shipwright's build controller on a Kubernetes cluster.
+            displayName: Shipwright Build
+            kind: ShipwrightBuild
+            name: shipwrightbuilds.operator.shipwright.io
+            version: v1alpha1
+        required:
+          - kind: TektonConfig
+            name: tektonconfigs.operator.tekton.dev
+            version: v1alpha1
+      description: "Builds for Red Hat OpenShift is an extensible build framework based on the Shipwright project, \nwhich you can use to build container images on an OpenShift Container Platform cluster. \nYou can build container images from source code and Dockerfile by using image build tools, \nsuch as Source-to-Image (S2I) and Buildah. You can create and apply build resources, view logs of build runs, \nand manage builds in your OpenShift Container Platform namespaces.\nRead more: [https://shipwright.io](https://shipwright.io)\n\n## Features\n\n* Standard Kubernetes-native API for building container images from source code and Dockerfile\n\n* Support for Source-to-Image (S2I) and Buildah build strategies\n\n* Extensibility with your own custom build strategies\n\n* Execution of builds from source code in a local directory\n\n* Shipwright CLI for creating and viewing logs, and managing builds on the cluster\n\n* Integrated user experience with the Developer perspective of the OpenShift Container Platform web console\n"
+      displayName: Builds for Red Hat OpenShift Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - build
+        - shipwright
+        - tekton
+        - cicd
+      labels:
+        operatorframework.io/arch.amd64: supported
+        operatorframework.io/arch.arm64: supported
+        operatorframework.io/arch.ppc64le: supported
+        operatorframework.io/arch.s390x: supported
+      links:
+        - name: Documentation
+          url: https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.2
+        - name: Builds for Openshift
+          url: https://github.com/redhat-openshift-builds/operator
+      maintainers:
+        - email: support@redhat.com
+          name: Red Hat OpenShift Builds Team
+      maturity: stable
+      minKubeVersion: 1.25.0
+      provider:
+        name: Red Hat
+        url: https://www.redhat.com
+relatedImages:
+  - image: registry.redhat.io/openshift-builds/openshift-builds-controller-rhel9@sha256:497d52f191554ca1e69858e6b963f61529acdcd2544c8f0308d97b5862b1b3f6
+    name: OPENSHIFT_BUILDS_CONTROLLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-git-cloner-rhel9@sha256:100e30705dc0c2d8bb9c0dc95db294493856b82d546c9b6599587dd340cee076
+    name: OPENSHIFT_BUILDS_GIT_CLONER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-bundler-rhel9@sha256:168eb59e4f4dcaa69ae59d96ba7d6b0be3009d6c89ea040ac000571e82b1547d
+    name: OPENSHIFT_BUILDS_IMAGE_BUNDLER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-image-processing-rhel9@sha256:b8118b072cebd47cb30a8afb561b6c7fffe4159ab0d349120facbda7e6efaf4d
+    name: OPENSHIFT_BUILDS_IMAGE_PROCESSING
+  - image: registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:29177a9d6cab538e97d35a0aff6aed31cebd068a34b49884dbab7af9d158ea48
+    name: OPENSHIFT_BUILDS_OPERATOR_BUNDLE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-rhel9-operator@sha256:aa47c4a7d83d797bd743414813bcd5dee1fb4f5a510397de31a521674d67d46f
+    name: OPENSHIFT_BUILDS_OPERATOR
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-rhel9@sha256:619494b414cfddaa9a75a07bb70570935c5c38944551da0537af302723476961
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE
+  - image: registry.redhat.io/openshift-builds/openshift-builds-shared-resource-webhook-rhel9@sha256:eaa6c528e069ca3674536ad1b47b06ea4772aa286eb6728ccacd90bb7a9602bf
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_WEBHOOK
+  - image: registry.redhat.io/openshift-builds/openshift-builds-waiters-rhel9@sha256:c8411c36a49c94a6ba0f702f9c1315e1d6314f7acb2a6eeb35815de6d8837e3e
+    name: OPENSHIFT_BUILDS_WAITER
+  - image: registry.redhat.io/openshift-builds/openshift-builds-webhook-rhel9@sha256:40838b6bd28a21ea88c411abea8bf6c192c6fbe03a417ab6602ca6d02b60946b
+    name: OPENSHIFT_BUILDS_WEBHOOK
+  - image: registry.redhat.io/openshift4/ose-csi-node-driver-registrar-rhel9@sha256:e8582857566020c71653228355cbadc2c1cda41e36fc767c204a4edb05e7f42a
+    name: OPENSHIFT_BUILDS_SHARED_RESOURCE_NODE_REGISTRAR
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:3fcd8e2bf0bcb8ff8c93a87af2c59a3bcae7be8792f9d3236c9b5bbd9b6db3b2
+    name: OPENSHIFT_BUILDS_KUBE_RBAC_PROXY
+  - image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:ed3fdd1e85f5c5434de6ec0feaec8c7fe4e680ca6c64258287f18ec2886bb71f
+    name: OPENSHIFT_BUILDS_SOURCE_TO_IMAGE
+  - image: registry.redhat.io/ubi9/buildah@sha256:27d837f9bc69ad3c3651cf3315e2501b137c11baa553d9d46140e5cf7fa7873a
     name: OPENSHIFT_BUILDS_BUILDAH
 schema: olm.bundle


### PR DESCRIPTION
Changes:
- Add builds-1.3 entries to 4.18 registry
- Revert operator-registry base image to registry.redhat.io since OCP 4.18 is released.