### PR TITLE
BUILD-1439: Add separate SA for taskRun

### DIFF
--- a/.tekton/openshift-builds-fbc-4-12-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-12-pull-request.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-12
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-12-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-12-push.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-12
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-13-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-13-pull-request.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-13
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-13-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-13-push.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-13
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-14-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-14-pull-request.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-14
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-14-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-14-push.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-14
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-15-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-15-pull-request.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-15
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-15-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-15-push.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-15
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-16-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-16-pull-request.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-16
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-16-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-16-push.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-16
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-17-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-17-pull-request.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-17
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-17-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-17-push.yaml
@@ -47,7 +47,8 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-17
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/openshift-builds-fbc-4-18-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-18-pull-request.yaml
@@ -47,19 +47,9 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-18
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/openshift-builds-fbc-4-18-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-18-push.yaml
@@ -47,19 +47,9 @@ spec:
         value: main
       - name: pathInRepo
         value: /pipelines/konflux-build-fbc.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openshift-builds-fbc-4-18
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Changes:
Latest update from Konflux requires the use of separate service account for all components.

Reference:
https://issues.redhat.com/browse/BUILD-1439