### PR TITLE
Fix dockerfile generation to use builder image from config file

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -37,7 +37,7 @@ generate_dockerfile() {
   fi
 
   # Generate Dockerfile
-  opm generate dockerfile -i "$image" "$path/$version/$package"
+  opm generate dockerfile -i "$image" -b "$image" "$path/$version/$package"
   mv "$path/$version"/*.Dockerfile "$path/$version"/Dockerfile
   success "Dockerfile"
 }


### PR DESCRIPTION
The dockerfile generation was using the builder image as the default image from upstream OPM. But for production release, we want the builder image used to be Red Hat OCP version specific index image.