### PR TITLE
Fix 4.19 pipeline

### DIFF
--- a/.tekton/openshift-builds-fbc-4-19-pull-request.yaml
+++ b/.tekton/openshift-builds-fbc-4-19-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        files.all.exists(x, x.matches('fbc/4.18')) ||
+        files.all.exists(x, x.matches('fbc/4.19')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-fbc-4-19-pull-request.yaml'))
       )
   creationTimestamp: null
@@ -34,7 +34,7 @@ spec:
     - name: dockerfile
       value: Dockerfile
     - name: path-context
-      value: fbc/4.18
+      value: fbc/4.19
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/openshift-builds-fbc-4-19-push.yaml
+++ b/.tekton/openshift-builds-fbc-4-19-push.yaml
@@ -10,7 +10,7 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        files.all.exists(x, x.matches('fbc/4.18')) ||
+        files.all.exists(x, x.matches('fbc/4.19')) ||
         files.all.exists(x, x.matches('.tekton/openshift-builds-fbc-4-19-push.yaml'))
       )
   creationTimestamp: null
@@ -31,7 +31,7 @@ spec:
     - name: dockerfile
       value: Dockerfile
     - name: path-context
-      value: fbc/4.18
+      value: fbc/4.19
     - name: build-platforms
       value:
         - linux/x86_64

--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,4 @@ catalog:
   - registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:6a4e331fe99dc1349e4682f3ffbc2102f60613e81ffde70ec039ecc8d32bd05c
   - registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:f2dcb453a2deaeb74ec9c7f2885ab88d4a119e93ebaef66dc1f1c52bffb9262e
   - registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:53d8cf8bf5c1103860ffc4110e2a422371761e76ee79edfef8680e947407c5ce
+  - registry.redhat.io/openshift-builds/openshift-builds-operator-bundle@sha256:aadba00eadb3ac46d321a14498fc3dffd5be9afbf698d80adddde0a7a1681fc4


### PR DESCRIPTION
# Changes:
- Fix, 4.19 pipeline was pointing to incorrect directory.
- Added 4.19 bundle to config.yaml as this is not automated. This is only necessary for building FBC from scratch.